### PR TITLE
release: v0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build wheel + sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install build
+        run: python -m pip install --upgrade pip build
+      - name: Build distribution
+        run: python -m build
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI (Trusted Publishing)
+    needs: build
+    runs-on: ubuntu-latest
+    # Trusted Publishing requires id-token: write. Configured on PyPI at
+    # https://pypi.org/manage/project/yc-ai-pulse/settings/publishing/
+    # against this repo + this workflow filename.
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/yc-ai-pulse
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Attach artifacts to GitHub release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Upload to GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh release upload "$TAG_NAME" dist/* --repo "$REPO" --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- Phase 0 bootstrap: MIT license, repo scaffolding, pre-commit + secret-scan, CI workflow, BACKLOG discipline, first ADR.
-- Phase 1 PR #1: yc-oss/api scraper, PII sanitizer, link verifier, coverage probe, single-file dashboard, Typer CLI (`ycai run-coverage`).
-- Coverage metric is the dashboard headline. The dropped register acknowledges every excluded company and the specific reason — no quiet drops.
-- First end-to-end probe on YC W26: 63.3% coverage of the official 196-company batch. Findings in `docs/QUALITY_REPORT_W26.md`.
-- Phase 1 PR #2: LLM-based enrichment with anti-hallucination Layer 1 — pydantic-enforced output schema, source-URL guard against fabricated citations, two-pass cross-check on uncertain rows, sentinel low-confidence row on any failure. Three backends: `AgentSDKBackend` (subscription-default), `AnthropicAPIBackend` (`--api-key`), `MockBackend` (tests). 10 hallucination-trap fixtures locked in as regression tests.
-- W26 enrichment smoke run (5 companies via subscription, 39s, ~free): 4 high / 1 low confidence. Identified `gru.space` as `no-ai` correctly. Schema-validation failure on `velum-labs` correctly fell through to the sentinel — no fabricated analysis served.
-- Phase 1 PR #3: enriched dashboard. AI capability x industry heatmap, tech-stack distribution, OSS-posture breakdown, and confidence breakdown — all with row-level drill-downs. Cited-URL link-verify hard gate before any artifact ships (override via `--allow-dead-links` writes a `BROKEN_LINKS.md` sidecar and shows a warning banner). Lenient parsing for `industry_secondary` so the model can emit reasonable categories without tanking the row.
-- W26 full-batch enrichment via subscription (124 companies, ~6 min, ~free): 83 high / 41 low confidence. Top finding: **65% of high-confidence W26 companies (54 of 83) build agents**. 8 companies correctly classified as `no-ai` (the trust signal). 3 cited URLs caught dead at publish time and surfaced via the publish gate.
-- Phase 1 PR #4: resilience + parser tightening. Lenient parsing extended to `ai_capability` (drop unknowns, fall back to `unclear`) and `tech_stack` (drop unknowns). `rationale` and `tagline_rewrite` truncate at the schema cap rather than fail the whole row. Raw failure capture (`raw_failures.jsonl`) for audit. Incremental writes to `analyses.jsonl` so partial state survives a crash. New `ycai resume <run-dir>` command resumes interrupted enrichment. New `ycai dashboard <run-dir>` re-renders the dashboard from existing artifacts at zero LLM cost. Live progress shows high/medium/low counts during enrichment.
-- W26 full-batch re-run after PR #4: schema-validation failure rate dropped from 23% to **0%**. High-confidence rate went from 67% to **95%** (118 of 124). The "W26 is the agentic batch" finding strengthened to 58% of n=118. Quality writeup updated at `docs/QUALITY_REPORT_W26.md`.
+_(no changes since 0.1.0)_
 
-[Unreleased]: https://github.com/RyanAlberts/yc-ai-pulse/compare/main...HEAD
+## [0.1.0] — 2026-05-01
+
+First publishable release. End-to-end pipeline that pulls the latest YC batch, classifies it with a Sonnet-class model under strict anti-hallucination guards, and renders a single-file HTML dashboard with row-level drill-downs.
+
+### Added
+
+**Phase 0 — bootstrap (PR #6 lineage starts here)**
+- MIT license, repo scaffolding, pre-commit + secret-scan + gitleaks + custom Anthropic-key regex, CI workflow, BACKLOG discipline, first two ADRs (yc-oss/api as the only sanctioned source; localhost FastAPI deferred to Phase 3).
+
+**Phase 1 — analysis pipeline**
+- **PR #6 — coverage probe**: yc-oss/api scraper with hard-fail when upstream is unreachable (no scraping `ycombinator.com/companies?...` per [robots.txt](docs/decisions/0001-yc-data-source.md)). PII sanitizer (idempotent strip before disk and before any LLM call). Async link verifier. Coverage probe with three tiers (A: full / B: website unreachable / C: missing required field) and a dropped register that names every excluded company. Coverage % is the dashboard headline.
+- **PR #7 — LLM enrichment with anti-hallucination Layer 1**: pydantic-enforced classification schema, three backends (AgentSDK / Anthropic API / Mock), source-URL grounding (the cited URL must come from the company's website or YC profile), two-pass cross-check on medium-confidence rows, sentinel low-confidence row on any failure. 10 hallucination-trap fixtures as regression tests.
+- **PR #8 — enriched dashboard + cited-URL publish gate**: capability×industry heatmap, tech-stack distribution, OSS-posture breakdown, confidence breakdown. Each chart drills down to source rows. Cited URLs are HEAD/GET-verified before publish; `--allow-dead-links` writes a sidecar `BROKEN_LINKS.md` and surfaces a banner.
+- **PR #9 — resilience + parser tightening**: schema-failure rate dropped 23% → 0%. Truncate-not-reject for verbose free-text fields (`rationale`, `tagline_rewrite`). Lenient parsing for `ai_capability` and `tech_stack`. Raw failure capture (`raw_failures.jsonl`). Incremental writes to `analyses.jsonl`. `ycai resume` recovers from interrupted runs. `ycai dashboard` re-renders from existing artifacts at zero LLM cost.
+
+**Real W26 results captured under `examples/output/`:**
+- 63.3% coverage of the 196-company batch (132 in upstream, 124 Tier A+B, 8 named drops, 4 Tier B with dead websites)
+- 118 of 124 high-confidence (95%) on the LLM enrichment, 0 schema failures, 0 hallucinated source URLs
+- **Top finding: 58% of high-confidence W26 companies build agents.** "W26 is the agentic batch" is now defensible with row-level evidence.
+
+### Backlog status at release
+
+| ID | Status | Note |
+|---|---|---|
+| B001 | resolved | yc-oss/api is sole source; ADR 0001 amended in PR #6 |
+| B002 | open | Cloudflare cache-headroom check on `yc-oss.github.io/api/*` |
+| B003 | open | Node 20 actions deprecated by 2026-06-02 — bump CI before then |
+| B004 | open | Calibrate `MIN_DESCRIPTION_CHARS` against borderline rows |
+| B005 | open | Name the missing-from-upstream W26 companies, not just count |
+| B006 | resolved | Schema-validation rate measured + tuned in PR #9 |
+| B007 | open | Depth=1 website crawl to recover `tech_stack` and `oss_posture` from `unknown` — biggest signal lever for v0.2 |
+| B008 | resolved | (rationale-cap root cause shipped in PR #9) |
+
+### Tests
+
+103 tests passing. Mypy `--strict` clean. CI runs ruff, mypy, pytest, detect-secrets, gitleaks, and a custom credential-pattern sweep on every PR.
+
+[Unreleased]: https://github.com/RyanAlberts/yc-ai-pulse/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/RyanAlberts/yc-ai-pulse/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -29,29 +29,42 @@ A Chrome extension wraps two flows: *(a)* analyze the whole batch, *(b)* deep-di
 
 | Phase | Surface | Status |
 |---|---|---|
-| 0 | Repo bootstrap, secrets hygiene, CI | 🟡 in progress |
-| 1 | CLI + dashboard | ⬜ planned |
+| 0 | Repo bootstrap, secrets hygiene, CI | ✅ shipped |
+| 1 | CLI + dashboard with anti-hallucination Layer 1 | ✅ **v0.1.0** |
 | 2 | `.pptx` + `.docx` reports | ⬜ planned |
 | 3 | Chrome extension | ⬜ planned |
 
-See [BACKLOG.md](BACKLOG.md) for the working backlog and `docs/decisions/` for architecture decisions.
+See [CHANGELOG.md](CHANGELOG.md) for what 0.1.0 includes, [BACKLOG.md](BACKLOG.md) for the working backlog, and `docs/decisions/` for architecture decisions.
 
-## Quickstart (Phase 1, when shipped)
-
-```bash
-pipx install yc-ai-pulse           # or: uv tool install yc-ai-pulse
-ycai run --depth quick             # ~5 min on Claude Max subscription
-ycai dashboard runs/2026-*-*/      # opens dashboard.html in your browser
-```
-
-By default `yc-ai-pulse` uses the [Claude Agent SDK](https://github.com/anthropics/anthropic-sdk-python) against your Claude Max subscription. To pay-per-run instead:
+## Quickstart (v0.1.0)
 
 ```bash
+pipx install yc-ai-pulse                                     # or: uv tool install yc-ai-pulse
+
+# Coverage probe only (no LLM cost) — fetches the latest batch and shows
+# what's analyzable. Headline: % of YC batch covered, with the dropped
+# register naming every excluded company.
+ycai run-coverage --batch winter-2026 --yc-official-count 196
+
+# Full enrichment via your Claude Max subscription (~6 min on W26, ~free).
+# 95% high-confidence rate. Renders the dashboard with capability heatmap,
+# tech-stack and OSS-posture breakdowns. Refuses to write the dashboard
+# if any cited URL is dead.
+ycai run-coverage --batch winter-2026 --yc-official-count 196 --enrich
+
+# Pay-per-token instead of subscription:
 export ANTHROPIC_API_KEY=sk-ant-...
-ycai run --depth full
+ycai run-coverage --batch winter-2026 --yc-official-count 196 --enrich
+
+# Resume an interrupted run (quota wall, crash, network blip):
+ycai resume runs/2026-05-01-XXXXXX
+
+# Re-render the dashboard from existing artifacts at zero LLM cost
+# (useful when the dashboard layout changes):
+ycai dashboard runs/2026-05-01-XXXXXX
 ```
 
-See [`docs/`](docs/) for the full guide.
+A real run on YC W26 is checked in as a working example: see [`examples/output/dashboard-w26-pr4-2026-05-01.html`](examples/output/dashboard-w26-pr4-2026-05-01.html). The full quality writeup is in [`docs/QUALITY_REPORT_W26.md`](docs/QUALITY_REPORT_W26.md).
 
 ## Anti-hallucination guarantees
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yc-ai-pulse"
-version = "0.0.1"
+version = "0.1.0"
 description = "Open-source YC batch analyzer — VC-style report and dashboard for the most recent Y Combinator batch."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -8,7 +8,7 @@ license = { file = "LICENSE" }
 authors = [{ name = "Ryan Alberts", email = "ryan.a.alberts@gmail.com" }]
 keywords = ["ycombinator", "yc", "ai", "analysis", "vc", "research", "dashboard"]
 classifiers = [
-  "Development Status :: 2 - Pre-Alpha",
+  "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3.11",

--- a/src/ycai/__init__.py
+++ b/src/ycai/__init__.py
@@ -3,4 +3,4 @@
 Phase 0 stub. Feature modules land in subsequent PRs.
 """
 
-__version__ = "0.0.1"
+__version__ = "0.1.0"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -9,7 +9,7 @@ from ycai.cli import app
 
 
 def test_package_imports() -> None:
-    assert ycai.__version__ == "0.0.1"
+    assert ycai.__version__ == "0.1.0"
 
 
 def test_cli_version_subcommand() -> None:


### PR DESCRIPTION
## What

The terminal Phase 1 PR. Bumps `0.0.1 → 0.1.0`, finalizes CHANGELOG, ships a PyPI Trusted-Publishing release workflow, and updates the README quickstart to the actual v0.1 commands.

Closes #5.

## What's in 0.1.0

| Layer | Status |
|---|---|
| Repo bootstrap, secrets hygiene, CI | ✅ Phase 0 |
| Scraper + sanitizer + coverage probe | ✅ PR #6 |
| LLM enrichment + anti-hallucination Layer 1 | ✅ PR #7 |
| Enriched dashboard + cited-URL publish gate | ✅ PR #8 |
| Resilience + parser tightening (0% schema-failure rate) | ✅ PR #9 |
| Release plumbing (this PR) | ✅ |

**103 tests passing. Mypy `--strict` clean. `make publish-check` clean.**

## Local smoke (already done)

```bash
python -m build
# -> dist/yc_ai_pulse-0.1.0-py3-none-any.whl  (38 KB)
# -> dist/yc_ai_pulse-0.1.0.tar.gz             (134 KB)

pipx install --force dist/yc_ai_pulse-0.1.0-py3-none-any.whl
ycai version
# yc-ai-pulse 0.1.0

cd /tmp/clean-dir
ycai run-coverage --batch winter-2026 --yc-official-count 196 --skip-link-check
# headline: 63.3% of Winter 2026 analyzed (124 of 196 companies)
```

## PyPI publish — one-time setup needed

The release workflow uses [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/), which needs a one-time configuration on the PyPI side:

1. Go to https://pypi.org/manage/account/publishing/
2. Add a new pending publisher:
   - **PyPI Project Name**: `yc-ai-pulse`
   - **Owner**: `RyanAlberts`
   - **Repo name**: `yc-ai-pulse`
   - **Workflow filename**: `release.yml`
   - **Environment name**: `pypi`
3. Optionally also configure on TestPyPI for dry-run testing.

Until that's done, the `publish` job in `release.yml` will fail; the `github-release` job still uploads the built wheels to the GitHub release. Re-running the workflow after PyPI setup will publish.

## Release sequence (after this PR merges)

```bash
git checkout main && git pull
git tag -a v0.1.0 -m "v0.1.0"
git push origin v0.1.0
# release.yml fires: build → publish (if Trusted Publishing configured) → attach to GitHub release
gh release create v0.1.0 --generate-notes --title "v0.1.0"
```

After release: close v0.1 milestone, promote B007 to a v0.2 issue, open v0.2 milestone.

## Backlog status at release

| ID | Status |
|---|---|
| B001 | resolved (PR #6 ADR amend) |
| B002 | open — yc-oss caching headroom check |
| B003 | open — Node 20 → Node 24 deadline 2026-06-02 |
| B004 | open — calibrate `MIN_DESCRIPTION_CHARS` |
| B005 | open — name missing-from-upstream W26 companies |
| B006 | resolved (PR #9) |
| B007 | open — depth=1 website crawl for `tech_stack` / `oss_posture`. **Biggest signal lever for v0.2.** |
| B008 | resolved (PR #9) |

## Acceptance

- [x] `python -m build` produces a clean wheel + sdist
- [x] `pipx install` works, `ycai version` returns 0.1.0
- [x] `ycai run-coverage` succeeds end-to-end from a clean dir
- [x] `release.yml` configured for PyPI Trusted Publishing
- [x] CHANGELOG.md reflects 0.1.0
- [x] All Phase 1 acceptance gates from the plan green
- [x] `make publish-check` clean
- [x] BACKLOG groomed; surviving items will move to v0.2 issues post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)