### PR TITLE
release: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_(no changes since 0.2.0)_
+
+## [0.2.0] — 2026-05-01
+
+Phase 2 release. Adds the depth=1 website crawler that lifts OSS-posture
+classification from 55% unknown to 21%, replaces the dashboard's static CSS
+bars with Apache ECharts, and ships the VC-style `.pptx` deck and narrative
+`.docx` memo with a second anti-hallucination layer that scans aggregate
+prose for forbidden hedge phrases and audits every number against the same
+dataframe the dashboard cites.
+
 ### Added
 - **PR #11 — depth=1 website crawl (B007 resolved)**: new `src/ycai/crawler.py` module. Polite, robots-aware, max 5 pages per company, 30 KB per page, 4-second timeout. Pages ranked by signal-path priority (`/pricing`, `/security`, `/about`, `/docs`, `/open-source`, …). HTML stripped and PII-sanitized before any LLM call. Crawled URLs are also accepted by the source-URL guard so the LLM can cite specific pages as evidence. New `--no-crawl` flag opts out.
 - W26 with crawler enabled: **OSS posture `unknown` rate dropped 55% → 21%** (target was <30%). Tech-stack identified mentions: 14 → 41. Vision capability: 17 → 26. Multimodal: 17 → 22.
@@ -56,5 +67,6 @@ First publishable release. End-to-end pipeline that pulls the latest YC batch, c
 
 103 tests passing. Mypy `--strict` clean. CI runs ruff, mypy, pytest, detect-secrets, gitleaks, and a custom credential-pattern sweep on every PR.
 
-[Unreleased]: https://github.com/RyanAlberts/yc-ai-pulse/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/RyanAlberts/yc-ai-pulse/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/RyanAlberts/yc-ai-pulse/releases/tag/v0.2.0
 [0.1.0]: https://github.com/RyanAlberts/yc-ai-pulse/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yc-ai-pulse"
-version = "0.1.0"
+version = "0.2.0"
 description = "Open-source YC batch analyzer — VC-style report and dashboard for the most recent Y Combinator batch."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/ycai/__init__.py
+++ b/src/ycai/__init__.py
@@ -3,4 +3,4 @@
 Phase 0 stub. Feature modules land in subsequent PRs.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -9,7 +9,7 @@ from ycai.cli import app
 
 
 def test_package_imports() -> None:
-    assert ycai.__version__ == "0.1.0"
+    assert ycai.__version__ == "0.2.0"
 
 
 def test_cli_version_subcommand() -> None:


### PR DESCRIPTION
Phase 2 release ceremony. Bumps version 0.1.0 → 0.2.0, finalizes CHANGELOG, smoke-builds the 0.2.0 wheel locally.

## What's in 0.2.0 (cumulative since 0.1.0)

| PR | What |
|---|---|
| #12 | Depth=1 polite website crawl (B007). OSS posture `unknown` rate dropped 55% → 21% on the same W26 cohort. |
| #13 | Apache ECharts replaces static CSS bars in the dashboard. Real interactive heatmap + tooltipped pies + bars. |
| #14 | VC-style `.pptx` deck (16 slides, a16z-feel palette) + anti-hallucination Layer 2 (forbidden-phrase scan + numerical-drift check). |
| #15 | Narrative `.docx` memo + dual-output `ycai report`. |

149 tests passing. `python -m build` produces a clean 0.2.0 wheel.

## Release sequence (after merge)

```bash
git checkout main && git pull
git tag -a v0.2.0 -m "v0.2.0"
git push origin v0.2.0
gh release create v0.2.0 --generate-notes --title "v0.2.0"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)